### PR TITLE
Escape template placeholders in htmlPage script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ const htmlPage = `<!DOCTYPE html>
           progress.value = 40;
           const { blob, quality } = await compressToTarget(canvas, TARGET_SIZE, progress, status);
 
-          updateStatus(`Finished at quality ${quality.toFixed(2)}. Size: ${(blob.size / 1024).toFixed(1)} KB`);
+          updateStatus(\`Finished at quality \${quality.toFixed(2)}. Size: \${(blob.size / 1024).toFixed(1)} KB\`);
           progress.value = 100;
 
           triggerDownload(blob, file.name.replace(/\.[^.]+$/, '') + '.webp');


### PR DESCRIPTION
## Summary
- escape the status update template literal markers within htmlPage so the outer template string remains intact during bundling

## Testing
- npx wrangler deploy *(fails: requires Cloudflare OAuth login in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e20950e48325b9b7f23781b2183d